### PR TITLE
feat: 接口前置URL兼容、环境baseUrl自动拼接、分享文档功能增强

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ AGENTS.md
 
 # Codex temporary artifacts
 .codex_tmp/
+apiflow-deploy-info.md
+docker-compose.local.yml
+opencode.json
+deploy_no_proxy.sh
+update-211.sh
+deploy-to-211.sh

--- a/packages/server/src/entity/doc/doc.ts
+++ b/packages/server/src/entity/doc/doc.ts
@@ -242,6 +242,11 @@ class RequestUrl {
   @prop({ default: '' })
   public host: string;
   /**
+   * 接口前缀（兼容前端 prefix 字段）
+   */
+  @prop({ default: '' })
+  public prefix: string;
+  /**
    * 请求路径
    */
   @prop({ default: '' })

--- a/packages/server/src/service/doc/doc.ts
+++ b/packages/server/src/service/doc/doc.ts
@@ -625,6 +625,9 @@ export class DocService {
       return websocketMockData;
     }
 
+    if (result.item?.url && !(result.item.url as { prefix?: string }).prefix) {
+      (result.item.url as { prefix: string }).prefix = result.item.url.host;
+    }
     return result;
   }
   /**

--- a/packages/server/src/service/doc/doc_import_export.ts
+++ b/packages/server/src/service/doc/doc_import_export.ts
@@ -1139,7 +1139,7 @@ export class DocImportAndExportService {
    * 导入apiflow格式文档
    */
   async importApiflow(params: ImportApiflowDto) {
-    const { projectId, cover, moyuData } = params;
+    const { projectId, cover, moyuData, deleteIds } = params;
     await this.commonControl.checkDocOperationPermissions(projectId);
     const { docs = [], hosts = [] } = moyuData;
     const convertDocs = docs.map((docInfo) => {
@@ -1152,12 +1152,20 @@ export class DocImportAndExportService {
       })
       const isFolder = docInfo.isFolder ?? (docInfo.info?.type === 'folder');
       const requestUrl = docInfo.item?.url as { host?: string; prefix?: string } | undefined;
-      if (requestUrl && !requestUrl.host && requestUrl.prefix) {
-        requestUrl.host = requestUrl.prefix;
+      if (requestUrl) {
+        if (!requestUrl.host && requestUrl.prefix) {
+          requestUrl.host = requestUrl.prefix;
+        }
+        if (!requestUrl.prefix && requestUrl.host) {
+          requestUrl.prefix = requestUrl.host;
+        }
       }
       docInfo.projectId = projectId;
       docInfo._id = newId;
       docInfo.isFolder = isFolder;
+      if (docInfo.info) {
+        docInfo.info.creator = this.ctx.tokenInfo?.loginName || '';
+      }
       if (!isFolder && docInfo.item) {
         docInfo.item.method = (docInfo.item.method?.toUpperCase() as RequestMethod) || 'GET';
       }
@@ -1171,6 +1179,12 @@ export class DocImportAndExportService {
     if (cover) {
       await this.docModel.updateMany({ projectId }, { $set: { isEnabled: false } })
       await this.docPrefixModel.updateMany({ projectId }, { $set: { isEnabled: false } });
+    }
+    if (deleteIds?.length > 0) {
+      await this.docModel.updateMany(
+        { _id: { $in: deleteIds }, projectId },
+        { $set: { isEnabled: false } }
+      );
     }
     await this.docPrefixModel.create(convertHosts);
     await this.docModel.create(convertDocs)

--- a/packages/server/src/types/dto/doc/doc.dto.ts
+++ b/packages/server/src/types/dto/doc/doc.dto.ts
@@ -186,7 +186,7 @@ class DocBaseInfo {
   /**
    * 创建者
    */
-  @Rule(RuleType.string())
+  @Rule(RuleType.string().allow(''))
   creator: string;
   /**
    * 维护人员，最近一次更新人员
@@ -282,6 +282,11 @@ class RequestUrl {
    */
   @Rule(RuleType.string().allow(''))
   public host: string;
+  /**
+   * url前缀
+   */
+  @Rule(RuleType.string().allow(''))
+  public prefix: string;
 }
 class RawBody {
   /**
@@ -388,8 +393,8 @@ export class DocInfo {
   /**
    * 是否为文件夹
    */
-  @Rule(RuleType.boolean().required())
-  isFolder: boolean;
+  @Rule(RuleType.boolean().default(false))
+  isFolder?: boolean;
   /**
    * 排序字段，时间戳
    */
@@ -427,9 +432,24 @@ export class DocInfo {
   responseParams: ResponseParams[];
   /**
    * mock信息
-  */
+   */
   @Rule(getSchema(MockInfo))
   mockInfo: MockInfo;
+  /**
+   * 是否删除
+   */
+  @Rule(RuleType.boolean().allow(true, false))
+  isDeleted?: boolean;
+  /**
+   * 创建时间
+   */
+  @Rule(RuleType.string().allow(''))
+  createdAt?: string;
+  /**
+   * 更新时间
+   */
+  @Rule(RuleType.string().allow(''))
+  updatedAt?: string;
 }
 export class ImportedDocInfo {
   /**
@@ -500,18 +520,38 @@ export class ImportedDocInfo {
   /**
    * 创建时间
    */
-  @Rule(RuleType.string())
+  @Rule(RuleType.string().allow(''))
   createdAt: string;
   /**
    * 更新时间
    */
-  @Rule(RuleType.string())
+  @Rule(RuleType.string().allow(''))
   updatedAt: string;
   /**
    * 是否删除
    */
   @Rule(RuleType.boolean())
   isEnabled: boolean;
+  /**
+   * 是否删除（前端兼容字段）
+   */
+  @Rule(RuleType.boolean().allow(true, false))
+  isDeleted?: boolean;
+  /**
+   * WebSocket节点数据
+   */
+  @Rule(getSchema(WebsocketItem))
+  websocketItem?: WebsocketItem;
+  /**
+   * WebSocketMock节点数据
+   */
+  @Rule(getSchema(WebsocketMockItem))
+  websocketMockItem?: WebsocketMockItem;
+  /**
+   * HttpMock节点数据
+   */
+  @Rule(getSchema(HttpMockItem))
+  httpMockItem?: HttpMockItem;
   /**
    * 子元素
    */

--- a/packages/server/src/types/dto/doc/doc.import.export.ts
+++ b/packages/server/src/types/dto/doc/doc.import.export.ts
@@ -122,4 +122,9 @@ export class ImportApiflowDto {
    */
   @Rule(getSchema(ApiflowDocInfo))
     moyuData: ApiflowDocInfo;
+  /**
+   * 需要覆盖删除的节点ID列表
+   */
+  @Rule(RuleType.array().items(RuleType.string()).optional())
+    deleteIds: string[];
 }

--- a/packages/web/src/renderer/server/request/request.ts
+++ b/packages/web/src/renderer/server/request/request.ts
@@ -143,8 +143,19 @@ export const getUrl = async (httpNode: HttpNode, temporaryVariables?: Record<str
     return objectPathParams[variableName] || ''
   }); // 替换路径参数
   const pathString = await getCompiledTemplate(replacedPathParamsString, variables);
-  const prefixString = url.prefix ? await getCompiledTemplate(url.prefix, variables) : '';
-  let fullUrl = prefixString + pathString + queryString;
+  const environmentStore = useEnvironment();
+  const activeEnvironment = environmentStore.activeEnvironment;
+  const baseUrl = activeEnvironment?.baseUrl || '';
+  let fullUrl = '';
+  if (url.prefix) {
+    const prefixString = await getCompiledTemplate(url.prefix, variables);
+    fullUrl = prefixString + pathString + queryString;
+  } else if (baseUrl && !pathString.trim().startsWith('http')) {
+    const prefixString = await getCompiledTemplate(baseUrl, variables);
+    fullUrl = prefixString + pathString + queryString;
+  } else {
+    fullUrl = pathString + queryString;
+  }
   if (!fullUrl.startsWith('http') && !fullUrl.startsWith('https')) {
     // 如果以/开头，需要去掉开头的/再添加http://，避免出现http:///
     if (fullUrl.startsWith('/')) {
@@ -164,7 +175,17 @@ export const getWebSocketUrl = async (websocketNode: WebSocketNode, temporaryVar
   const objectVariable = await getObjectVariable(variables);
   const { url, queryParams } = websocketNode.item;
   const queryString = await getStringFromParams(queryParams, objectVariable, { checkSelect: true, addQuestionMark: true });
-  let fullUrl = url.path + queryString;
+  const wsPathString = await getCompiledTemplate(url.path, variables);
+  const wsEnvironmentStore = useEnvironment();
+  const wsActiveEnvironment = wsEnvironmentStore.activeEnvironment;
+  const wsBaseUrl = wsActiveEnvironment?.baseUrl || '';
+  let fullUrl = '';
+  if (wsBaseUrl && !wsPathString.trim().startsWith('ws')) {
+    const wsPrefixString = await getCompiledTemplate(wsBaseUrl, variables);
+    fullUrl = wsPrefixString + wsPathString + queryString;
+  } else {
+    fullUrl = wsPathString + queryString;
+  }
   if (!fullUrl.startsWith('ws') && !fullUrl.startsWith('wss')) {
     // 如果以/开头，需要只添加一个/，避免出现ws:///
     if (fullUrl.startsWith('/')) {


### PR DESCRIPTION
## 概述

本次 PR 包含以下功能改进和修复：

### 1. .gitignore 更新
- 排除本地配置文件（`docker-compose.local.yml`、`apiflow-deploy-info.md`、`opencode.json`）
- 排除部署脚本（`deploy_no_proxy.sh`、`deploy-to-211.sh`、`update-211.sh`）

### 2. RequestUrl prefix 字段兼容
**问题**：前端 HTTP 节点使用 `url.prefix` 存储前置 URL，但后端 Entity 只定义了 `url.host`，导致：
- 新数据存 `prefix`，后端导出用 `host`，导出地址缺失前缀
- 旧数据存 `host`，前端读 `prefix`，请求地址缺失前缀

**修改**：
- Entity 新增 `prefix` 字段（`default: ''`）
- 查询详情时 `prefix` 为空则用 `host` 回填（兼容旧数据）
- 导入时 `prefix`/`host` 互转，确保两个字段都有值
- `ImportApiflowDto` 新增 `deleteIds` 字段（支持导入覆盖删除）

### 3. 环境 baseUrl 自动拼接
**问题**：用户设置了环境 `baseUrl`，但发送请求时 URL 没有拼接 `baseUrl` 前缀。原因是 UI 中 host 选择器被注释，`url.prefix` 始终为空。

**修改**：
- `url.prefix` 有值 → 使用 `prefix`（原有逻辑）
- `url.prefix` 为空 + `path` 不以 `http` 开头 + `baseUrl` 有值 → 自动拼接 `baseUrl`
- WebSocket 同理，`wsPath` 不以 `ws`/`wss` 开头时拼接 `baseUrl`

### 4. 分享文档功能增强
**问题**：
1. 之前只能分享整个项目，无法选择特定接口文档
2. 无密码分享时会报错，必须设置密码
3. 分享页使用 `window.location.search` 获取参数，但 `/share` 是 hash 路由，`search` 永远为空
4. 分享页打开的接口文档 URL 没有拼接 `prefix`/`host` 前缀

**修改**：
- 后端：查询分享信息时返回 `projectId` 和 `selectedDocs`，按 `selectedDocs` 过滤文档树，无密码分享直接返回
- 后端：`password` 字段改为 `.allow('')`，支持无密码分享
- 前端：`/share` 加入匿名访问白名单，排除自动跳转
- 前端：用 `useRoute().query` 替代 `window.location.search`
- 前端：URL 拼接时 fallback 到 `url.host`（兼容旧数据）

### 5. 单接口分享对话框
**功能**：在 HTTP 接口编辑页面新增"分享"按钮，支持单接口分享
- 支持设置密码（可选）
- 支持设置过期时间（1天/1周/1个月/不过期）
- 生成分享链接并支持一键复制
- 传入 `selectedDocs` 仅分享当前接口

## 提交记录

1. `chore: update .gitignore to exclude local config and deploy scripts`
2. `feat: add prefix field to RequestUrl for host/prefix compatibility`
3. `feat: auto-prepend environment baseUrl when url.prefix is empty`
4. `feat: share document with selected docs and password-optional support`
5. `feat: add single document share dialog in Operation page`