### PR TITLE
修复creator报错和权限问题

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,119 @@
+# Apiflow 源码构建与升级部署文档
+
+> 适用场景：官方 Docker 镜像版本滞后于 Release 时，从源码自行构建镜像并升级线上部署。
+> 本文档基于 `v0.9.51` + 导入功能修复（`fix/import-children-creator` 分支）编写。
+
+## 一、背景说明
+
+- 官方镜像（`xiaoxiaoshu/apiflow-*`，Docker Hub）停留在 v0.9.5（2026-08-17），v0.9.51（2026-08-31）未推送镜像。
+- v0.9.5 → v0.9.51 之间 **server / website 无任何代码改动**，只有 web（前端）有 3 个提交。
+- 本仓库在 v0.9.51 基础上额外修复了一个导入缺陷（嵌套文件夹内的文档 creator 为空导致导入报错，issue #44 未修完整），修复在分支 `fix/import-children-creator`，仅改动 web 前端一个文件。
+
+## 二、构建环境要求
+
+- Docker 20.10+（含 buildx）
+- Git
+- 磁盘空间 ≥ 5GB
+- 如服务器在国内网络环境，构建命令中加 `--build-arg USE_NPM_MIRROR=true`（使用 npmmirror 源）
+
+## 三、获取源码
+
+```bash
+git clone https://github.com/trueleaf/apiflow.git
+cd apiflow
+git checkout fix/import-children-creator   # = v0.9.51 + 导入修复
+```
+
+## 四、构建镜像
+
+**在仓库根目录执行**（Dockerfile 的构建上下文是仓库根目录，不是各子包目录）：
+
+```bash
+docker build -t xiaoxiaoshu/apiflow-server:latest \
+  -f packages/server/Dockerfile . --build-arg USE_NPM_MIRROR=true
+
+docker build -t xiaoxiaoshu/apiflow-website:latest \
+  -f packages/website/Dockerfile . --build-arg USE_NPM_MIRROR=true
+
+docker build -t xiaoxiaoshu/apiflow-web:latest \
+  -f packages/web/Dockerfile . --build-arg USE_NPM_MIRROR=true
+```
+
+镜像名必须保持 `xiaoxiaoshu/apiflow-*:latest` 不变，`docker-compose.yml` 会直接引用。
+
+参考构建耗时：server / website / web 各约 1 分钟内（有缓存时更快）。
+
+### 关于 Mongo 镜像（重要）
+
+**不要重建、不要替换 `xiaoxiaoshu/apiflow-mongo:6` 镜像，也不要删除 `mongo_data` 数据卷。**
+线上数据都在该卷里。Mongo 镜像内容就是官方 `mongo:6`，无需任何变更，compose 启动时会复用已有镜像和卷。
+
+## 五、线上升级步骤
+
+前置条件：线上已有官方镜像部署（含 `docker-compose.yml`、`.env`、`mongo_data` 卷）。
+
+### 1. 备份（必做）
+
+```bash
+# 备份 Mongo 数据（在部署目录执行）
+docker compose exec mongo mongodump \
+  --username "$MONGO_ROOT_USERNAME" --password "$MONGO_ROOT_PASSWORD" \
+  --authenticationDatabase admin \
+  --archive=/data/db/backup_$(date +%Y%m%d).archive --gzip
+docker compose cp mongo:/data/db/backup_$(date +%Y%m%d).archive ./backup_$(date +%Y%m%d).archive
+```
+
+### 2. 检查 .env
+
+确认 `.env` 中的 `MONGO_ROOT_USERNAME` / `MONGO_ROOT_PASSWORD` 与**首次部署时一致**。
+Mongo 的账号密码只在数据卷首次初始化时生效，改 `.env` 里的密码会导致认证失败、服务起不来。
+
+### 3. 替换镜像并重启
+
+将第四步构建好的三个镜像导入线上机器（`docker save` / `docker load`，或推到内部 registry 后改 compose 里的镜像名），然后：
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+**禁止执行** `docker compose pull` 或 `./update.sh`——它们会从 Docker Hub 拉取旧的官方 latest，覆盖掉本地构建的镜像。
+
+### 4. 验证
+
+```bash
+# 容器健康状态
+docker compose ps        # mongo / server 应为 healthy
+
+# API 健康检查
+curl http://localhost/api/health
+# 期望返回: {"code":0,"msg":"操作成功","data":{"status":"ok"}}
+
+# 前端版本：浏览器访问后，页面源码/bundle 中版本号应为 0.9.51
+```
+
+功能验证：登录后进入项目，导入带 tags 的 OpenAPI 3.0 文档（嵌套文件夹结构），应能导入成功（issue #44 场景）。
+
+## 六、回滚
+
+```bash
+docker compose down
+docker compose pull        # 拉回官方镜像（v0.9.5）
+docker compose up -d
+```
+
+数据卷不受镜像切换影响，回滚不会丢数据。
+
+## 七、常见问题
+
+| 现象 | 原因 | 处理 |
+|------|------|------|
+| mongo 容器 unhealthy，日志报 `Authentication failed: storedKey mismatch` | `.env` 的 Mongo 密码与数据卷初始化时不一致 | 改回首次部署时的密码 |
+| 升级后页面功能/版本仍是旧的 | 浏览器缓存了旧前端 | 硬刷新（Cmd/Ctrl+Shift+R）或无痕窗口 |
+| 镜像被覆盖回旧版 | 执行了 `docker compose pull` / `update.sh` | 重新执行第四节构建命令 |
+| 导入报 `docs[0].children[0].info.creator 不允许为空` | web 镜像不是 `fix/import-children-creator` 分支构建的 | 确认源码分支后重新构建 web 镜像 |
+| 导入报 `item.url.prefix 不被允许` | web 镜像是旧版修复（只改了 creator），未包含 prefix→host 改名 | 拉取最新 `fix/import-children-creator` 分支重新构建 web 镜像 |
+
+## 八、后续
+
+官方补推 v0.9.51+ 镜像、并合并导入修复后，可恢复官方更新流程（`./update.sh`）。届时留意 https://github.com/trueleaf/apiflow/issues/44 的进展。

--- a/BUILD.md
+++ b/BUILD.md
@@ -113,6 +113,7 @@ docker compose up -d
 | 镜像被覆盖回旧版 | 执行了 `docker compose pull` / `update.sh` | 重新执行第四节构建命令 |
 | 导入报 `docs[0].children[0].info.creator 不允许为空` | web 镜像不是 `fix/import-children-creator` 分支构建的 | 确认源码分支后重新构建 web 镜像 |
 | 导入报 `item.url.prefix 不被允许` | web 镜像是旧版修复（只改了 creator），未包含 prefix→host 改名 | 拉取最新 `fix/import-children-creator` 分支重新构建 web 镜像 |
+| 打开项目报"内部错误"，每次都弹 | 之前失败的导入在浏览器 IndexedDB 残留了无效标签页，旧服务端对非法文档 id 直接抛 500 | 用最新分支重建 **server + web** 镜像；新服务端返回业务错误 4001，前端会提示"当前接口不存在"并允许一键关闭标签。临时处理：清除该站点的网站数据后重新登录 |
 
 ## 八、后续
 

--- a/packages/server/src/service/doc/doc.ts
+++ b/packages/server/src/service/doc/doc.ts
@@ -533,6 +533,9 @@ export class DocService {
   async getDocDetail(params: GetDocDetailDto) {
     const { _id, projectId } = params;
     await this.commonControl.checkDocOperationPermissions(projectId, 'readOnly');
+    if (!Types.ObjectId.isValid(_id)) {
+      throwError(4001, '暂无文档信息')
+    }
     const result = await this.docModel.findOne({ _id }, { pid: 0, sort: 0, isEnabled: 0 }).lean();
     if (!result) {
       throwError(4001, '暂无文档信息')

--- a/packages/server/src/service/project/project.ts
+++ b/packages/server/src/service/project/project.ts
@@ -122,11 +122,18 @@ export class ProjectService {
         throwError(1014, '项目成员数量超过限制')
       }
       const groupInfo = await this.groupModel.findOne({ _id: id }).lean();
+      if (!groupInfo) {
+        throwError(1003, '团队不存在')
+      }
+      if (projectInfo.groups.some(group => group.groupId === id)) {
+        throwError(1003, '该用户组已在项目内')
+      }
       await this.projectModel.findByIdAndUpdate({ _id: projectId }, {
         $push: { groups: {
           groupId: id,
           groupName: name,
-          permission
+          permission,
+          groupUsers: groupInfo.members
         } }
       });
       const memberIds = groupInfo.members.map(v => v.userId);

--- a/packages/web/src/renderer/api/api.ts
+++ b/packages/web/src/renderer/api/api.ts
@@ -192,13 +192,16 @@ axiosInstance.interceptors.response.use(
         case 4004: //暂无当前接口权限
           message.warning(i18n.global.t(res.data.msg || '暂无当前接口权限'));
           return Promise.reject(new Error(i18n.global.t(res.data.msg || '暂无当前接口权限')));
-        default:
+        default: {
           ElMessageBox.confirm(i18n.global.t(res.data.msg ? res.data.msg : '操作失败'), i18n.global.t('提示'), {
             confirmButtonText: i18n.global.t('确定/ApiErrorDialog'),
             showCancelButton: false,
             type: 'warning',
           });
-          return Promise.reject(new Error(i18n.global.t(res.data.msg)));
+          const bizError = new Error(i18n.global.t(res.data.msg)) as Error & { code?: number };
+          bizError.code = res.data.code;
+          return Promise.reject(bizError);
+        }
       }
       return result;
     }

--- a/packages/web/src/renderer/pages/projectWorkbench/layout/content/import/Import.vue
+++ b/packages/web/src/renderer/pages/projectWorkbench/layout/content/import/Import.vue
@@ -428,6 +428,11 @@ const handleSubmit = async () => {
       if (doc.children && doc.children.length > 0) {
         normalizedDoc.children = doc.children.map(child => normalizeDoc(child as ImportDoc))
       }
+      // 服务端 DTO 不认识的字段不能提交（如 isDeleted），否则校验报"不被允许"
+      delete (normalizedDoc as Record<string, unknown>).isDeleted
+      // createdAt/updatedAt 为空字符串会被 DTO 拒绝，由服务端生成时间戳
+      if (!normalizedDoc.createdAt) delete (normalizedDoc as Record<string, unknown>).createdAt
+      if (!normalizedDoc.updatedAt) delete (normalizedDoc as Record<string, unknown>).updatedAt
       return normalizedDoc
     }
     const docs = formInfo.value.moyuData.docs.map(val => {

--- a/packages/web/src/renderer/pages/projectWorkbench/layout/content/import/Import.vue
+++ b/packages/web/src/renderer/pages/projectWorkbench/layout/content/import/Import.vue
@@ -404,29 +404,36 @@ const handleSubmit = async () => {
       return
     }
     const mountedId = currentMountedNode.value?._id
-    const docs = formInfo.value.moyuData.docs.map(val => {
+    type ImportDoc = (HttpNode | FolderNode) & { children?: (HttpNode | FolderNode)[] }
+    // 递归规范化文档：嵌套在文件夹 children 里的文档同样需要兜底 creator 和 host
+    const normalizeDoc = (doc: ImportDoc): ImportDoc => {
       const normalizedDoc = {
-        ...val,
-        pid: !val.pid && mountedId ? mountedId : val.pid,
-        isFolder: val.info.type === 'folder',
+        ...doc,
+        isFolder: doc.info.type === 'folder',
         info: {
-          ...val.info,
-          creator: val.info.creator || runtimeStore.userInfo.loginName,
+          ...doc.info,
+          creator: doc.info.creator || runtimeStore.userInfo.loginName,
         },
-      }
-      if (!('item' in val)) {
-        return normalizedDoc
-      }
-      return {
-        ...normalizedDoc,
-        item: {
-          ...val.item,
+      } as ImportDoc
+      if ('item' in doc) {
+        const { prefix, ...restUrl } = doc.item.url
+        ;(normalizedDoc as HttpNode).item = {
+          ...doc.item,
           url: {
-            ...val.item.url,
-            host: val.item.url.prefix,
+            ...restUrl,
+            host: prefix,
           },
-        },
+        }
       }
+      if (doc.children && doc.children.length > 0) {
+        normalizedDoc.children = doc.children.map(child => normalizeDoc(child as ImportDoc))
+      }
+      return normalizedDoc
+    }
+    const docs = formInfo.value.moyuData.docs.map(val => {
+      const normalizedDoc = normalizeDoc(val as ImportDoc)
+      normalizedDoc.pid = !val.pid && mountedId ? mountedId : val.pid
+      return normalizedDoc
     })
     if (isStandalone.value && formInfo.value.cover) {
       const copiedDocs = JSON.parse(JSON.stringify(docs)) as HttpNode[]

--- a/packages/web/src/renderer/store/httpNode/httpNodeStore.ts
+++ b/packages/web/src/renderer/store/httpNode/httpNodeStore.ts
@@ -530,6 +530,26 @@ export const useHttpNode = defineStore('httpNode', () => {
         projectId: payload.projectId,
         _id: payload.id,
       }
+      // 接口不存在时提示用户关闭接口（数据为 null 或返回 4001）
+      const promptCloseMissingDoc = () => {
+        ClConfirm({
+          content: i18n.global.t('当前接口不存在，可能已经被删除'),
+          title: i18n.global.t('提示'),
+          confirmButtonText: i18n.global.t('关闭接口'),
+          cancelButtonText: i18n.global.t('取消'),
+          type: 'warning',
+        }).then(() => {
+          deleteNavByIds({
+            projectId: payload.projectId,
+            ids: [payload.id]
+          })
+        }).catch((err) => {
+          if (err === 'cancel' || err === 'close') {
+            return;
+          }
+          console.error(err);
+        });
+      }
       axiosInstance.get<CommonResponse<HttpNode>, CommonResponse<HttpNode>>('/api/project/doc_detail', {
         params,
         cancelToken: new axios.CancelToken((c) => {
@@ -537,29 +557,18 @@ export const useHttpNode = defineStore('httpNode', () => {
         }),
       }).then((res) => {
         if (res.data === null) { //接口不存在提示用户删除接口
-          ClConfirm({
-            content: i18n.global.t('当前接口不存在，可能已经被删除'),
-            title: i18n.global.t('提示'),
-            confirmButtonText: i18n.global.t('关闭接口'),
-            cancelButtonText: i18n.global.t('取消'),
-            type: 'warning',
-          }).then(() => {
-            deleteNavByIds({
-              projectId: payload.projectId,
-              ids: [payload.id]
-            })
-          }).catch((err) => {
-            if (err === 'cancel' || err === 'close') {
-              return;
-            }
-            console.error(err);
-          });
+          promptCloseMissingDoc();
           return;
         }
         changeHttpNodeInfo(res.data);
         changeOriginHttpNodeInfo()
         resolve()
       }).catch((err) => {
+        if ((err as { code?: number })?.code === 4001) { //接口不存在（含无效的文档id）
+          promptCloseMissingDoc();
+          reject(err);
+          return;
+        }
         console.error(err);
         reject(err);
       }).finally(() => {


### PR DESCRIPTION
1、修复creator不存在，主要是多层级导入问题
2、用户组授权给项目时，该项目里的组快照是空数组（Mongoose 数组默认 []）→ 组内成员在这个项目里匹配不到 → 列表看不到、访问报 4002 暂无当前项目权限。只有"创建项目时就带上组"的那些项目是好的 → 表现为只有部分项目有权